### PR TITLE
setting timeout = None to minimize CPU usage

### DIFF
--- a/oemgatewaylistener.py
+++ b/oemgatewaylistener.py
@@ -103,7 +103,7 @@ class OemGatewayListener(object):
         self._log.debug('Opening serial port: %s', com_port)
         
         try:
-            s = serial.Serial(com_port, 9600, timeout = 0)
+            s = serial.Serial(com_port, 9600, timeout = None)
         except serial.SerialException as e:
             self._log.error(e)
             raise OemGatewayListenerInitError('Could not open COM port %s' %


### PR DESCRIPTION
Without this change, my raspberry used almost all the cpu permanently (~95%).
According to pyserial documentation (http://pyserial.sourceforge.net/pyserial_api.html), setting timeout to 0 will set the device in non-blocking mode, when None is the blocking mode.
